### PR TITLE
Use an old version of rlang and vctrs

### DIFF
--- a/cloud-init.txt
+++ b/cloud-init.txt
@@ -70,7 +70,10 @@ write_files:
       permissions: '0755'
     - encoding: text/plain
       content: |
-        install.packages(c("remotes", "tibble", "here", "config", "txtq"))
+        install.packages(c("remotes", "here", "config", "txtq"))
+        remotes::install_version("rlang", version = "1.0.6") #TODO: Bump to a more recent version of R instead
+        remotes::install_version("vctrs", version = "0.5.2")
+        install.packages("tibble") 
       path: '/home/azureuser/dependencies.R'
       permissions: '0755'
 


### PR DESCRIPTION
We use UbuntuLTS (presumably 18.04?) as the base image for this process. 
That image has R=3.5.0 available: https://rtask.thinkr.fr/installation-of-r-3-5-on-ubuntu-18-04-lts-and-tips-for-spatial-packages/

`rlang` depends on `R >= 3.5.0`
so does `vctrs`

To continue using this image, we thus must use old installations of these packages. 

Note: we may consider bumping to UbuntuLTS 20.04: https://www.r-bloggers.com/2020/05/installation-of-r-4-0-on-ubuntu-20-04-lts-and-tips-for-spatial-packages/
