### PR TITLE
Assign new machines to "Server" subnet of RMI VNET

### DIFF
--- a/run_many.sh
+++ b/run_many.sh
@@ -1,11 +1,15 @@
+SUBNETID=$(az network vnet subnet show --resource-group RMI-PROD-EU-VNET-RG --name Server --vnet-name RMI-PROD-EU-VNET --query id -o tsv)
+
 az vm create \
     --resource-group MFM2022 \
     --name mrdc-runner-C- \
+    --subnet $SUBNETID \
     --image UbuntuLTS \
     --assign-identity /subscriptions/feef729b-4584-44af-a0f9-4827075512f9/resourceGroups/UST-2022/providers/Microsoft.ManagedIdentity/userAssignedIdentities/PACTA-runner \
     --admin-username azureuser \
     --public-ip-address "" \
     --size "Standard_E4-2as_v4" \
     --count 5 \
+    --generate-ssh-keys \
     --custom-data cloud-init.txt
 

--- a/run_single_ssh.sh
+++ b/run_single_ssh.sh
@@ -1,12 +1,14 @@
+SUBNETID=$(az network vnet subnet show --resource-group RMI-PROD-EU-VNET-RG --name Server --vnet-name RMI-PROD-EU-VNET --query id -o tsv)
+
 az vm create \
     --resource-group UST-2022 \
     --name pacta-runner-ssh \
     --image UbuntuLTS \
     --assign-identity /subscriptions/feef729b-4584-44af-a0f9-4827075512f9/resourceGroups/UST-2022/providers/Microsoft.ManagedIdentity/userAssignedIdentities/PACTA-runner \
     --admin-username azureuser \
-    --public-ip-address UST03-ip \
-    --public-ip-sku Basic \
-    --ssh-key-name UST-VM-key \
+    --subnet $SUBNETID \
+    --public-ip-address "" \
     --size "Standard_E4-2as_v4" \
+    --generate-ssh-keys \
     --custom-data cloud-init.txt
 


### PR DESCRIPTION
This change includes code to identify the RMI Virtual network, and assign new VMs to the "Server" subnet.\

We can then access those machines using SSH over the RMI VPN.